### PR TITLE
Allow local git checkout for Jenkins

### DIFF
--- a/docker/controller/Dockerfile
+++ b/docker/controller/Dockerfile
@@ -5,7 +5,8 @@ ENV JENKINS_PASS admin
 
 # Skip initial setup
 # Disable script approval checks
-ENV JAVA_OPTS -Xmx2048m -Djava.awt.headless=true -Djenkins.install.runSetupWizard=false -Dpermissive-script-security.enabled=true
+# Allow local git checkout
+ENV JAVA_OPTS -Xmx2048m -Djava.awt.headless=true -Djenkins.install.runSetupWizard=false -Dpermissive-script-security.enabled=true -Dhudson.plugins.git.GitSCM.ALLOW_LOCAL_CHECKOUT=true
 
 
 COPY plugins.txt /usr/share/jenkins/plugins.txt


### PR DESCRIPTION
add parameter for Jenkins start so it can work with jobs that checkout from local directory (mounted volumes with other repos)
`Dhudson.plugins.git.GitSCM.ALLOW_LOCAL_CHECKOUT=true`